### PR TITLE
[BC] Support grouping backups by cluster name

### DIFF
--- a/manifests/cron_backup.pp
+++ b/manifests/cron_backup.pp
@@ -3,6 +3,7 @@
 # Typically on a catalog (backup) server.
 define pgprobackup::cron_backup(
   String                          $id,
+  String                          $cluster,
   String                          $host_group,
   Pgprobackup::Backup_type        $backup_type,
   String                          $server_address,
@@ -123,7 +124,7 @@ define pgprobackup::cron_backup(
 
     @@cron { "pgprobackup_${backup_type}_${server_address}-${host_group}":
       command  => @("CMD"/L),
-      ${binary} ${backup_cmd} --instance ${id} -b ${backup_type} ${stream}--remote-host=${server_address}\
+      ${binary} ${backup_cmd} --instance ${cluster} -b ${backup_type} ${stream}--remote-host=${server_address}\
        --remote-user=${remote_user} --remote-port=${remote_port} -U ${db_user} -d ${db_name}\
        ${logging}${retention}${_threads}${_temp_slot}${_slot}${_validate}${_compress}${_timeout}
       | -CMD

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -66,7 +66,7 @@
 #   include pgprobackup::instance
 class pgprobackup::instance(
   String                            $id                   = $::hostname,
-  String                            $cluster              = $::hostname,
+  Optional[String]                  $cluster              = undef,
   String                            $server_address       = $::fqdn,
   Integer                           $server_port          = 5432,
   Boolean                           $manage_dbuser        = true,
@@ -106,6 +106,11 @@ class pgprobackup::instance(
   Integer                           $compress_level       = 1,
   Optional[Integer]                 $archive_timeout      = undef,
   ) inherits pgprobackup {
+
+  $_cluster = $cluster ? {
+    undef   => $id,
+    default => $cluster
+  }
 
   class {'pgprobackup::install':
     versions       => [$version],
@@ -213,12 +218,12 @@ class pgprobackup::instance(
 
       @@exec { "pgprobackup_add_instance_${::fqdn}-${host_group}":
         command => @("CMD"/L),
-        pg_probackup-${version} add-instance -B ${backup_dir} --instance ${id} \
+        pg_probackup-${version} add-instance -B ${backup_dir} --instance ${_cluster} \
         --remote-host=${server_address} --remote-user=${remote_user} \
         --remote-port=${remote_port} -D ${db_dir}/${version}/${db_cluster}
         | -CMD
         path    => ['/usr/bin'],
-        onlyif  => "test ! -d ${backup_dir}/backups/${id}",
+        onlyif  => "test ! -d ${backup_dir}/backups/${_cluster}",
         tag     => "pgprobackup_add_instance-${host_group}",
         user    => $backup_user, # note: error output might not be captured
         require => Package["${package_name}-${version}"],
@@ -245,6 +250,7 @@ class pgprobackup::instance(
           # declare cron job, use defaults from instance
           create_resources(pgprobackup::cron_backup, {"cron_backup-${host_group}-${server_address}-${backup_type}" => $schedule} , {
             id                   => $id,
+            cluster              => $_cluster,
             db_name              => $db_name,
             db_user              => $db_user,
             version              => $version,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -4,10 +4,18 @@
 #
 # @param id
 #   Unique identifier within `host_group`
+# @param cluster
+#   Could be used to group primary with standby servers
 # @param server_address
 #   Address used for connecting to the DB server
 # @param server_port
 #   DB port
+# @param db_name
+#   Database used for backups
+# @param db_user
+#   User connecting to database
+# @param db_cluster
+#   Postgresql cluster e.g. `main`
 # @param db_dir
 #   PostgreSQL home directory
 # @param manage_dbuser
@@ -58,13 +66,14 @@
 #   include pgprobackup::instance
 class pgprobackup::instance(
   String                            $id                   = $::hostname,
+  String                            $cluster              = $::hostname,
   String                            $server_address       = $::fqdn,
-  String                            $cluster              = 'main',
   Integer                           $server_port          = 5432,
   Boolean                           $manage_dbuser        = true,
   String                            $db_dir               = '/var/lib/postgresql',
   String                            $db_name              = $pgprobackup::db_name,
   String                            $db_user              = $pgprobackup::db_user,
+  String                            $db_cluster           = 'main',
   Variant[String,Sensitive[String]] $db_password          = '',
   Optional[String]                  $seed                 = undef,
   String                            $remote_user          = 'postgres',
@@ -206,7 +215,7 @@ class pgprobackup::instance(
         command => @("CMD"/L),
         pg_probackup-${version} add-instance -B ${backup_dir} --instance ${id} \
         --remote-host=${server_address} --remote-user=${remote_user} \
-        --remote-port=${remote_port} -D ${db_dir}/${version}/${cluster}
+        --remote-port=${remote_port} -D ${db_dir}/${version}/${db_cluster}
         | -CMD
         path    => ['/usr/bin'],
         onlyif  => "test ! -d ${backup_dir}/backups/${id}",

--- a/spec/classes/instance_spec.rb
+++ b/spec/classes/instance_spec.rb
@@ -56,13 +56,14 @@ describe 'pgprobackup::instance' do
             }
           },
           version: '12',
+          db_cluster: 'dev',
         }
       end
 
       it {
         expect(exported_resources).to contain_exec('pgprobackup_add_instance_psql.localhost-common').with(
           tag: 'pgprobackup_add_instance-common',
-          command: 'pg_probackup-12 add-instance -B /var/lib/pgbackup --instance foo --remote-host=psql.localhost --remote-user=postgres --remote-port=22 -D /var/lib/postgresql/12/main',
+          command: 'pg_probackup-12 add-instance -B /var/lib/pgbackup --instance foo --remote-host=psql.localhost --remote-user=postgres --remote-port=22 -D /var/lib/postgresql/12/dev',
         )
       }
 

--- a/spec/classes/instance_spec.rb
+++ b/spec/classes/instance_spec.rb
@@ -668,7 +668,6 @@ describe 'pgprobackup::instance' do
       end
     end
 
-
     context 'install specific package version' do
       let(:params) do
         {


### PR DESCRIPTION
Backups from primary and standby (preferably standby) can be stored in the same directory.